### PR TITLE
Better handling for signed vs unsigned 32-bit values

### DIFF
--- a/core/Engine.ts
+++ b/core/Engine.ts
@@ -860,6 +860,7 @@ module FyreVM {
 		  }
 
  		  streamNumCore(x: number){
+			    x = x | 0;
 			    if (this.outputSystem === IOSystem.Filter){
 					this.pushCallStub(GLULX_STUB.RESUME_FUNC, 0, this.PC, this.FP);
 					let num = x.toString();

--- a/core/MemoryAccess.ts
+++ b/core/MemoryAccess.ts
@@ -277,8 +277,7 @@ module FyreVM {
 		}
 		
 		writeInt32(offset: number, value: number){
-			if (value < 0 || value > 0xFFFFFFFF)
-				throw new Error(`${value} is out of range for uint32`);
+			value = value >>> 0;
 			this.set(offset, [ value >> 24, value >> 16 & 0xFF, value >> 8 & 0xFF, value & 0xFF])
 		}
 		

--- a/core/Opcodec.ts
+++ b/core/Opcodec.ts
@@ -22,13 +22,7 @@ module FyreVM {
 	
 	// coerce Javascript number into uint32 range
 	function uint32(x:number) : number{
-		if (x < 0){
-			x = 0xFFFFFFFF + x  + 1;
-		}
-		if (x > 0xFFFFFFFF){
-			x %= 0x100000000;
-		}
-		return x;
+		return x >>> 0;
 	}
 	function uint16(x: number) :number{
 		if (x < 0){

--- a/core/Opcodes.ts
+++ b/core/Opcodes.ts
@@ -90,22 +90,13 @@ module FyreVM {
 	
 	// coerce Javascript number into uint32 range
 	function uint32(x:number) : number{
-		if (x < 0){
-			x = 0xFFFFFFFF + x  + 1;
-		}
-		if (x > 0xFFFFFFFF){
-			x %= 0x100000000;
-		}
-		return x;
+		return x >>> 0;
 	}
 	
 	// coerce uint32 number into  (signed!) int32 range
 	
 	function int32(x: number) :number{
-		if (x > 0xF0000000){
-			x = - (0xFFFFFFFF - x + 1);
-		}
-		return x;
+		return x | 0;
 	}
 	
 	
@@ -127,13 +118,13 @@ module FyreVM {
 				function(a,b){ return uint32(a-b)});				
 		
 			opcode(0x12, 'mul', 2, 1,
-				function(a,b){ return uint32(a*b)});
+				function(a,b){ return uint32(int32(a)*int32(b))});
 		
 			opcode(0x13, 'div', 2, 1,
-				function(a,b){ return Math.floor(a / b)});
+				function(a,b){ return int32(int32(a) / int32(b))});
 		
 			opcode(0x14, 'mod', 2, 1,
-				function(a,b){ return a % b});
+				function(a,b){ return int32(a) % int32(b)});
 	
 			// TODO: check the specs
 			opcode(0x15, 'neg', 1, 1,

--- a/core/Opcodes.ts
+++ b/core/Opcodes.ts
@@ -121,10 +121,10 @@ module FyreVM {
 				function(a,b){ return uint32(int32(a)*int32(b))});
 		
 			opcode(0x13, 'div', 2, 1,
-				function(a,b){ return int32(int32(a) / int32(b))});
+				function(a,b){ return uint32(int32(a) / int32(b))});
 		
 			opcode(0x14, 'mod', 2, 1,
-				function(a,b){ return int32(a) % int32(b)});
+				function(a,b){ return uint32(int32(a) % int32(b))});
 	
 			// TODO: check the specs
 			opcode(0x15, 'neg', 1, 1,

--- a/core/Opcodes.ts
+++ b/core/Opcodes.ts
@@ -390,14 +390,16 @@ module FyreVM {
 
 			opcode(0x4B, "aloadbit", 2, 1,
 				function(array: number, index: number){
-					let address = array + Math.floor(index / 8);
-					index %= 8;
-					if (index < 0){
-						address--;
-						index += 8;
+					index = int32(index);
+					let bitx = index & 7;
+					let address = array;
+					if (index >= 0){
+						address += (index>>3);
+					}else{
+						address -= (1+((-1-index)>>3));
 					}
 					let byte =  this.image.readByte(uint32(address));
-					return byte & (1 << index) ? 1 : 0;
+					return byte & (1 << bitx) ? 1 : 0;
 				});
 
 			opcode(0x4C, "astore", 3, 0,
@@ -421,17 +423,19 @@ module FyreVM {
 
 			opcode(0x4F, "astorebit", 3, 0,
 				function(array: number, index: number, value: number){
-					let address = array + Math.floor(index / 8);
-					index %= 8;
-					if (index < 0){
-						address--;
-						index += 8;
+					index = int32(index);
+					let bitx = index & 7;
+					let address = array;
+					if (index >= 0){
+						address += (index>>3);
+					}else{
+						address -= (1+((-1-index)>>3));
 					}
 					let byte =  this.image.readByte(address);
 					if (value === 0){
-						byte &= ~(1 << index);
+						byte &= ~(1 << bitx);
 					}else{
-						byte |= (1 << index);
+						byte |= (1 << bitx);
 					}
 					this.image.writeBytes(address, byte);
 				}

--- a/core/Opcodes.ts
+++ b/core/Opcodes.ts
@@ -150,7 +150,7 @@ module FyreVM {
 			opcode(0x1C, 'shiftl', 2, 1,
 				function(a,b){ 
 					if (uint32(b) >= 32) return 0;
-					return a << b});
+					return uint32(a << b)});
 
 			opcode(0x1D, 'sshiftr', 2, 1,
 				function(a,b){ 

--- a/core/Opcodes.ts
+++ b/core/Opcodes.ts
@@ -147,23 +147,20 @@ module FyreVM {
 			opcode(0x1B, 'bitnot', 1, 1,
 				function(x){ x = ~uint32(x); if (x<0) return 1 + x + 0xFFFFFFFF; return x; });
 	
-			// TODO: check if it works, JS has signed ints, we want uint
 			opcode(0x1C, 'shiftl', 2, 1,
 				function(a,b){ 
-					if (b >= 32) return 0;
+					if (uint32(b) >= 32) return 0;
 					return a << b});
 
-			// TODO: check if it works, JS has signed ints, we want uint
 			opcode(0x1D, 'sshiftr', 2, 1,
 				function(a,b){ 
-					if (b >= 32) return (a & 0x80000000) ? 0 : 0xFFFFFFFF;
-					return a >> b});
+					if (uint32(b) >= 32) return (a & 0x80000000) ? 0xFFFFFFFF : 0;
+					return uint32(int32(a) >> b)});
 			
-			// TODO: check if it works, JS has signed ints, we want uint
 			opcode(0x1E, 'ushiftr', 2, 1,
 				function(a,b){ 
-					if (b >= 32) return 0;
-					return a >> b});
+					if (uint32(b) >= 32) return 0;
+					return uint32(uint32(a) >>> b)});
 					
 					
 			opcode(0x20, 'jump', 1, 0, 

--- a/core/UlxImage.ts
+++ b/core/UlxImage.ts
@@ -120,8 +120,7 @@ module FyreVM {
 		// the image has access to the MemoryAccess object
 		// (which the Engine does not)
 		allocateStack(): MemoryAccess {
-			// TODO: using copy is ugly, we just need a new buffer
-			return this.memory.copy(0, this.getStackSize());
+			return new Uint8ArrayMemoryAccess(4 * this.getStackSize());
 		}
 	
 		readByte(address: number) : number {

--- a/node/core-on-node.ts
+++ b/node/core-on-node.ts
@@ -39,7 +39,7 @@ module FyreVM{
 		}
 		
 		writeInt32(offset: number, value: number){
-			this.buffer.writeUInt32BE(value, offset || 0);
+			this.buffer.writeUInt32BE(value >>> 0, offset || 0);
 		}
 		
 		readASCII(offset: number, length: number): string{


### PR DESCRIPTION
I tried out the glulxercise test (http://eblong.com/zarf/glulx/glulxercise.ulx) and ran into some bugs immediately.

The worst is an exception when writing negative numbers to memory (run the "arith" test, for example). This fixes that.
